### PR TITLE
feat: replace browser reload with in-place reset for VS "New" diagram

### DIFF
--- a/Visual Studio/CodeMindMap/CodeMindMapHtml.cs
+++ b/Visual Studio/CodeMindMap/CodeMindMapHtml.cs
@@ -387,6 +387,83 @@ namespace CodeMindMap
 
         };
 
+        window.resetMindMap = function() {
+            if (!mind) return;
+
+            const defaultData = {
+                nodeData: {
+                    id: 'me-root',
+                    topic: 'Code Mind Map',
+                    children: [
+                        {
+                            topic: 'Code',
+                            id: 'bd1f03fee1f63bc6',
+                            direction: 0,
+                            expanded: true,
+                            children: [
+                                {
+                                    topic: 'Ctrl+2, Ctrl+2 \u2014 add the selected code (line under the caret) as a node linked to the code.',
+                                    id: 'bd1f07c598e729dc',
+                                },
+                                {
+                                    topic: 'Ctrl+click on a node - jump to the code linked to the node.',
+                                    id: 'bd1bb4b14d6697c3',
+                                },
+                            ],
+                        },
+                        {
+                            topic: 'Mind Map',
+                            id: 'bd1b66c4b56754d9',
+                            direction: 1,
+                            expanded: true,
+                            children: [
+                                {
+                                    topic: 'Alt+Scroll - Zoom in/out',
+                                    id: 'bd1c1cb51e6745d3',
+                                },
+                                {
+                                    topic: 'Shift+Scroll - Scroll horizontally',
+                                    id: '16710cea5cfb50712c8832676b87d2cc',
+                                },
+                                {
+                                    topic: 'Right Click+Drag - Move the mind map',
+                                    id: 'bd1c1e12fd603ff6',
+                                },
+                                {
+                                    topic: 'tab - Create a child node',
+                                    id: 'bd1b6892bcab126a',
+                                },
+                                {
+                                    topic: 'enter - Create a sibling node',
+                                    id: 'bd1b6b632a434b27',
+                                },
+                                {
+                                    topic: 'del - Remove a node',
+                                    id: 'bd1b983085187c0a',
+                                },
+                                {
+                                    topic: 'space - Expand/collapse nodes',
+                                    id: 'bd1bb2ac4bbab458',
+                                },
+                            ],
+                        },
+                    ],
+                    expanded: true,
+                },
+                theme: themeManager.getTheme('Light'),
+                direction: 2
+            };
+
+            // mind.refresh() does not restore direction, so apply it manually first.
+            mind.direction = defaultData.direction;
+            mind.refresh(defaultData);
+            mind.clearHistory();
+
+            if (defaultData.theme && themeManager.contains(defaultData.theme.name) && defaultData.theme.name !== mind.theme?.name) {
+                mind.changeTheme(defaultData.theme);
+            }
+        };
+
         if (document.readyState === 'loading') {
             document.addEventListener('DOMContentLoaded', initMindMap);
         } else {

--- a/Visual Studio/CodeMindMap/MindMapToolWindowControl.xaml.cs
+++ b/Visual Studio/CodeMindMap/MindMapToolWindowControl.xaml.cs
@@ -298,7 +298,7 @@ namespace CodeMindMap
             return sb.ToString();
         }
 
-        private void NewCodeMindMapClick(object sender, RoutedEventArgs eventArgs)
+        private async void NewCodeMindMapClick(object sender, RoutedEventArgs eventArgs)
         {
             var dialogResult = MessageBox.Show("Create a new code mind map?", "Code Mind Map", MessageBoxButton.OKCancel, MessageBoxImage.Exclamation);
 
@@ -311,7 +311,10 @@ namespace CodeMindMap
             MindMapPackage?.SetDefaultSolutionMindMapData();
             MindMapPackage?.SaveSolutionMindMapDataToSettings();
 
-            ReloadMindMapBrowser();
+            if (IsBrowserReady)
+            {
+                await MindMapBrowser.ExecuteScriptAsync("resetMindMap();");
+            }
         }
 
         public void ReloadMindMapBrowser()


### PR DESCRIPTION
## Motivation

The VS Code and Visual Studio plugins previously handled the "New diagram" action differently:

- **VS Code** — the webview is persistent, so "New" calls `mind.refresh(defaultData)` + `mind.clearHistory()` on the existing `mind` instance.
- **Visual Studio** — "New" called `MindMapBrowser.Reload()`, which destroyed and recreated the entire browser context, resetting history as a side effect.

This PR aligns the Visual Studio plugin with the VS Code approach so both plugins use the same mechanism: an in-place `mind.refresh()` + `mind.clearHistory()`.

## Changes

### `CodeMindMapHtml.cs`
Added a `window.resetMindMap()` JS function that:
1. Builds the same default node tree used during `initMindMap()`
2. Applies the direction before calling `mind.refresh()` (same workaround already used in `importData`)
3. Calls `mind.refresh(defaultData)` + `mind.clearHistory()`
4. Resets the theme to Light if needed

### `MindMapToolWindowControl.xaml.cs`
Changed `NewCodeMindMapClick` to call `await MindMapBrowser.ExecuteScriptAsync("resetMindMap()")` instead of `ReloadMindMapBrowser()`. The C# side (package data management) is unchanged.

## Result

Both plugins now reset the mind map in-place without a full browser reload. History is cleared explicitly via `clearHistory()` in both cases.