### PR TITLE
Remove fullscreen button from MindElixir toolbar

### DIFF
--- a/VS Code/MindElixir/MindElixir.js
+++ b/VS Code/MindElixir/MindElixir.js
@@ -1539,12 +1539,30 @@ const Hn = '<?xml version="1.0" standalone="no"?><!DOCTYPE svg PUBLIC "-//W3C//D
   return n.id = e, n.innerHTML = Xn[t], n;
 };
 function Kn(e) {
-  const t = document.createElement("div"), n = U("toCenter", "living"), o = U("zoomout", "zoomout"), s = U("zoomin", "zoomin");
-  return t.appendChild(n), t.appendChild(o), t.appendChild(s), t.className = "mind-elixir-toolbar rb", n.onclick = () => {
-    e.toCenter();
+  const t = document.createElement("div"), n = U("fullscreen", "full"), o = U("toCenter", "living"), s = U("zoomout", "zoomout"), i = U("zoomin", "zoomin");
+  t.appendChild(n), t.appendChild(o), t.appendChild(s), t.appendChild(i), t.className = "mind-elixir-toolbar rb";
+  let l = null;
+  const c = () => {
+    const a = e.container.getBoundingClientRect(), d = Ze(e.map.style.transform), h = a.width / 2, u = a.height / 2, y = (h - d.x) / e.scaleVal, v = (u - d.y) / e.scaleVal;
+    l = {
+      containerRect: a,
+      currentTransform: d,
+      mapCenterX: y,
+      mapCenterY: v
+    };
+  }, r = () => {
+    if (l) {
+      const a = e.container.getBoundingClientRect(), d = a.width / 2, h = a.height / 2, u = d - l.mapCenterX * e.scaleVal, y = h - l.mapCenterY * e.scaleVal, v = u - l.currentTransform.x, p = y - l.currentTransform.y;
+      e.move(v, p);
+    }
+  };
+  return e.el.addEventListener("fullscreenchange", r), n.onclick = () => {
+    c(), document.fullscreenElement !== e.el ? e.el.requestFullscreen() : document.exitFullscreen();
   }, o.onclick = () => {
-    e.scale(e.scaleVal - e.scaleSensitivity);
+    e.toCenter();
   }, s.onclick = () => {
+    e.scale(e.scaleVal - e.scaleSensitivity);
+  }, i.onclick = () => {
     e.scale(e.scaleVal + e.scaleSensitivity);
   }, t;
 }

--- a/VS Code/src/extension.ts
+++ b/VS Code/src/extension.ts
@@ -699,6 +699,17 @@ export class CodeMindMapPanel {
             background: #1e1e1e; 
             color: #fff; 
         }
+        .mind-elixir-toolbar #fullscreen {
+            display: none;
+        }
+        .mind-elixir-toolbar.rb {
+            display: flex;
+            gap: 10px;
+            align-items: center;
+        }
+        .mind-elixir-toolbar.rb span + span {
+            margin-left: 0;
+        }
         #container { 
             height: 100vh; 
             display: flex; 

--- a/Visual Studio/CodeMindMap/CodeMindMapHtml.cs
+++ b/Visual Studio/CodeMindMap/CodeMindMapHtml.cs
@@ -21,6 +21,17 @@ namespace CodeMindMap
     <title>Code Mind Map</title>
     <link rel=""stylesheet"" href=""http://codemindmap.vsext/MindElixir.css"">
     <style>
+        .mind-elixir-toolbar #fullscreen {
+            display: none;
+        }
+        .mind-elixir-toolbar.rb {
+            display: flex;
+            gap: 10px;
+            align-items: center;
+        }
+        .mind-elixir-toolbar.rb span + span {
+            margin-left: 0;
+        }
         #map {
             width: 100%;
             height: 100vh;

--- a/Visual Studio/CodeMindMap/MindElixir/MindElixir.js
+++ b/Visual Studio/CodeMindMap/MindElixir/MindElixir.js
@@ -1539,12 +1539,30 @@ const Hn = '<?xml version="1.0" standalone="no"?><!DOCTYPE svg PUBLIC "-//W3C//D
   return n.id = e, n.innerHTML = Xn[t], n;
 };
 function Kn(e) {
-  const t = document.createElement("div"), n = U("toCenter", "living"), o = U("zoomout", "zoomout"), s = U("zoomin", "zoomin");
-  return t.appendChild(n), t.appendChild(o), t.appendChild(s), t.className = "mind-elixir-toolbar rb", n.onclick = () => {
-    e.toCenter();
+  const t = document.createElement("div"), n = U("fullscreen", "full"), o = U("toCenter", "living"), s = U("zoomout", "zoomout"), i = U("zoomin", "zoomin");
+  t.appendChild(n), t.appendChild(o), t.appendChild(s), t.appendChild(i), t.className = "mind-elixir-toolbar rb";
+  let l = null;
+  const c = () => {
+    const a = e.container.getBoundingClientRect(), d = Ze(e.map.style.transform), h = a.width / 2, u = a.height / 2, y = (h - d.x) / e.scaleVal, v = (u - d.y) / e.scaleVal;
+    l = {
+      containerRect: a,
+      currentTransform: d,
+      mapCenterX: y,
+      mapCenterY: v
+    };
+  }, r = () => {
+    if (l) {
+      const a = e.container.getBoundingClientRect(), d = a.width / 2, h = a.height / 2, u = d - l.mapCenterX * e.scaleVal, y = h - l.mapCenterY * e.scaleVal, v = u - l.currentTransform.x, p = y - l.currentTransform.y;
+      e.move(v, p);
+    }
+  };
+  return e.el.addEventListener("fullscreenchange", r), n.onclick = () => {
+    c(), document.fullscreenElement !== e.el ? e.el.requestFullscreen() : document.exitFullscreen();
   }, o.onclick = () => {
-    e.scale(e.scaleVal - e.scaleSensitivity);
+    e.toCenter();
   }, s.onclick = () => {
+    e.scale(e.scaleVal - e.scaleSensitivity);
+  }, i.onclick = () => {
     e.scale(e.scaleVal + e.scaleSensitivity);
   }, t;
 }


### PR DESCRIPTION
## Summary
- removes the fullscreen toolbar button from the embedded MindElixir toolbar
- keeps host-side control of fullscreen behavior instead of exposing it in the in-map toolbar
- updates both bundled copies used by VS Code and Visual Studio variants

## Commits
1. Revert fullscreen button fix in MindElixir.js
2. Remove fullscreen button

## Notes
- source branch: `DisciplinedSoftware:fix/remove-fullscreen-host-side`
- target branch: `main`